### PR TITLE
vsgExamples complain about not linking OpenThreads in release builds

### DIFF
--- a/src/osg2vsg/CMakeLists.txt
+++ b/src/osg2vsg/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(osg2vsg PUBLIC
 target_link_libraries(osg2vsg PUBLIC
     vsg::vsg
     Vulkan::Vulkan
-    ${OSG_LIBRARIES} ${OSGUTIL_LIBRARIES} ${OSGDB_LIBRARIES}
+    ${OPENTHREADS_LIBRARIES} ${OSG_LIBRARIES} ${OSGUTIL_LIBRARIES} ${OSGDB_LIBRARIES}
 )
 
 

--- a/src/osg2vsg/osg2vsgConfig.cmake
+++ b/src/osg2vsg/osg2vsgConfig.cmake
@@ -2,6 +2,7 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Vulkan)
 find_dependency(vsg)
+find_dependency(OpenThreads)
 find_dependency(osg)
 find_dependency(osgUtil)
 find_dependency(osgDB)


### PR DESCRIPTION
These changes add OpenThreads as a dependancy of osg2vsg