### PR TITLE
Added SPIRV-Tools and SPIRV-Tools-opt libraries to the CMake build system

### DIFF
--- a/CMakeModules/Findglslang.cmake
+++ b/CMakeModules/Findglslang.cmake
@@ -33,7 +33,6 @@ find_path(spirv_INCLUDE_DIR
     NAMES SPIRV/GlslangToSpv.h
 )
 
-
 find_library(glslang_LIBRARY
     NAMES glslang
 )
@@ -46,6 +45,14 @@ find_library(SPIRV_LIBRARY
     NAMES SPIRV
 )
 
+find_library(SPIRV-Tools_LIBRARY
+    NAMES SPIRV-Tools
+)
+
+find_library(SPIRV-Tools-opt_LIBRARY
+    NAMES SPIRV-Tools-opt
+)
+
 find_library(OGLCompiler_LIBRARY
     NAMES OGLCompiler
 )
@@ -55,26 +62,33 @@ find_library(HLSL_LIBRARY
 )
 
 if(WIN32)
+    find_library(glslang_LIBRARY_debug
+        NAMES glslangd
+    )
 
-  find_library(glslang_LIBRARY_debug
-      NAMES glslangd
-  )
+    find_library(OSDependent_LIBRARY_debug
+        NAMES OSDependentd
+    )
 
-  find_library(OSDependent_LIBRARY_debug
-      NAMES OSDependentd
-  )
+    find_library(SPIRV_LIBRARY_debug
+        NAMES SPIRVd
+    )
 
-  find_library(SPIRV_LIBRARY_debug
-      NAMES SPIRVd
-  )
+    find_library(SPIRV-Tools_LIBRARY_debug
+        NAMES SPIRV-Toolsd
+    )
 
-  find_library(OGLCompiler_LIBRARY_debug
-      NAMES OGLCompilerd
-  )
+    find_library(SPIRV-Tools-opt_LIBRARY_debug
+        NAMES SPIRV-Tools-optd
+    )
 
-  find_library(HLSL_LIBRARY_debug
-      NAMES HLSLd
-  )
+    find_library(OGLCompiler_LIBRARY_debug
+        NAMES OGLCompilerd
+    )
+
+    find_library(HLSL_LIBRARY_debug
+        NAMES HLSLd
+    )
 endif()
 
 
@@ -92,28 +106,36 @@ else()
 endif()
 
 if(glslang_FOUND AND NOT TARGET glslang::glslang)
-  add_library(glslang::glslang UNKNOWN IMPORTED)
-  set_target_properties(glslang::glslang PROPERTIES IMPORTED_LOCATION "${glslang_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${glslang_INCLUDE_DIRS}")
+    add_library(glslang::glslang UNKNOWN IMPORTED)
+    set_target_properties(glslang::glslang PROPERTIES IMPORTED_LOCATION "${glslang_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${glslang_INCLUDE_DIRS}")
 
-  add_library(glslang::OSDependent UNKNOWN IMPORTED)
-  set_target_properties(glslang::OSDependent PROPERTIES IMPORTED_LOCATION "${OSDependent_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${glslang_INCLUDE_DIRS}")
+    add_library(glslang::OSDependent UNKNOWN IMPORTED)
+    set_target_properties(glslang::OSDependent PROPERTIES IMPORTED_LOCATION "${OSDependent_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${glslang_INCLUDE_DIRS}")
 
-  add_library(glslang::SPIRV UNKNOWN IMPORTED)
-  set_target_properties(glslang::SPIRV PROPERTIES IMPORTED_LOCATION "${SPIRV_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${spirv_INCLUDE_DIR}")
+    add_library(glslang::SPIRV UNKNOWN IMPORTED)
+    set_target_properties(glslang::SPIRV PROPERTIES IMPORTED_LOCATION "${SPIRV_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${spirv_INCLUDE_DIR}")
 
-  add_library(glslang::OGLCompiler UNKNOWN IMPORTED)
-  set_target_properties(glslang::OGLCompiler PROPERTIES IMPORTED_LOCATION "${OGLCompiler_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${glslang_INCLUDE_DIRS}")
+    add_library(glslang::SPIRV-Tools UNKNOWN IMPORTED)
+    set_target_properties(glslang::SPIRV-Tools PROPERTIES IMPORTED_LOCATION "${SPIRV-Tools_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${spirv_INCLUDE_DIR}")
 
-  add_library(glslang::HLSL UNKNOWN IMPORTED)
-  set_target_properties(glslang::HLSL PROPERTIES IMPORTED_LOCATION "${HLSL_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${glslang_INCLUDE_DIRS}")
+    add_library(glslang::SPIRV-Tools-opt UNKNOWN IMPORTED)
+    set_target_properties(glslang::SPIRV-Tools-opt PROPERTIES IMPORTED_LOCATION "${SPIRV-Tools-opt_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${spirv_INCLUDE_DIR}")
 
-  if(WIN32)
-    set_target_properties(glslang::glslang PROPERTIES IMPORTED_LOCATION_DEBUG "${glslang_LIBRARY_debug}")
-    set_target_properties(glslang::OSDependent PROPERTIES IMPORTED_LOCATION_DEBUG "${OSDependent_LIBRARY_debug}")
-    set_target_properties(glslang::SPIRV PROPERTIES IMPORTED_LOCATION_DEBUG "${SPIRV_LIBRARY_debug}")
-    set_target_properties(glslang::OGLCompiler PROPERTIES IMPORTED_LOCATION_DEBUG "${OGLCompiler_LIBRARY_debug}")
-    set_target_properties(glslang::HLSL PROPERTIES IMPORTED_LOCATION_DEBUG "${HLSL_LIBRARY_debug}")
-  endif()
+    add_library(glslang::OGLCompiler UNKNOWN IMPORTED)
+    set_target_properties(glslang::OGLCompiler PROPERTIES IMPORTED_LOCATION "${OGLCompiler_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${glslang_INCLUDE_DIRS}")
+
+    add_library(glslang::HLSL UNKNOWN IMPORTED)
+    set_target_properties(glslang::HLSL PROPERTIES IMPORTED_LOCATION "${HLSL_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${glslang_INCLUDE_DIRS}")
+
+    if(WIN32)
+        set_target_properties(glslang::glslang PROPERTIES IMPORTED_LOCATION_DEBUG "${glslang_LIBRARY_debug}")
+        set_target_properties(glslang::OSDependent PROPERTIES IMPORTED_LOCATION_DEBUG "${OSDependent_LIBRARY_debug}")
+        set_target_properties(glslang::SPIRV PROPERTIES IMPORTED_LOCATION_DEBUG "${SPIRV_LIBRARY_debug}")
+        set_target_properties(glslang::SPIRV PROPERTIES IMPORTED_LOCATION_DEBUG "${SPIRV-Tools_LIBRARY_debug}")
+        set_target_properties(glslang::SPIRV PROPERTIES IMPORTED_LOCATION_DEBUG "${SPIRV-Tools-opt_LIBRARY_debug}")
+        set_target_properties(glslang::OGLCompiler PROPERTIES IMPORTED_LOCATION_DEBUG "${OGLCompiler_LIBRARY_debug}")
+        set_target_properties(glslang::HLSL PROPERTIES IMPORTED_LOCATION_DEBUG "${HLSL_LIBRARY_debug}")
+    endif()
 
 endif()
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ You'll need a build of OpenSceneGraph to use osg2vsg, if you don't have one go a
 
     https://github.com/openscenegraph/OpenSceneGraph
 
-You'll also need glslLang inorder to compile GLSL shaders to Vulkan compatible SPIR-V shaders at runtime. glslLang can be downloaded and built using the following.
+You'll also need glslLang inorder to compile GLSL shaders to Vulkan compatible SPIR-V shaders at runtime. glslLang can be downloaded and built using the following (Alternatively, you could use glslLang version bundled with LunarG SDK and located in `SDK_INSTALL_PATH/glslang`).
 
     git clone https://github.com/KhronosGroup/glslang.git
     cd ./glsllang
+    ./update_glslang_sources.py
     cmake . -G "Visual Studio 15 2017 Win64"
     
 Open the generated Visual Studio solution file (Ensure you start Visual Studi as Admin if installing to the default location). Build install target for debug and release and finally add the install location (default C:\Program Files\glslang) to CMAKE_PREFIX_PATH environment variable.

--- a/applications/osg2vsg/CMakeLists.txt
+++ b/applications/osg2vsg/CMakeLists.txt
@@ -32,6 +32,8 @@ target_link_libraries(osg2vsg_viewer
     glslang::glslang
     glslang::OSDependent
     glslang::SPIRV
+    glslang::SPIRV-Tools
+    glslang::SPIRV-Tools-opt
     glslang::OGLCompiler
     glslang::HLSL
     Vulkan::Vulkan

--- a/src/osg2vsg/CMakeLists.txt
+++ b/src/osg2vsg/CMakeLists.txt
@@ -37,6 +37,8 @@ target_link_libraries(osg2vsg PUBLIC
     glslang::glslang
     glslang::OSDependent
     glslang::SPIRV
+    glslang::SPIRV-Tools
+    glslang::SPIRV-Tools-opt
     glslang::OGLCompiler
     glslang::HLSL
     Vulkan::Vulkan

--- a/src/osgPlugins/vsg/CMakeLists.txt
+++ b/src/osgPlugins/vsg/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(osgdb_vsg PUBLIC
     glslang::glslang
     glslang::OSDependent
     glslang::SPIRV
+    glslang::SPIRV-Tools
+    glslang::SPIRV-Tools-opt
     glslang::OGLCompiler
     glslang::HLSL
     Vulkan::Vulkan


### PR DESCRIPTION
@tomhog On Windows, using "VS 15 2017 Community Edition" I got several linker errors for all methods defined in `SPIRV-Tools` and `SPIRV-Tools-opt` libraries. Does it compile on your system without these two libraries? If yes, I'm wondering what I'm missing then. I have tried both glslang versions - one from github and one from LunarSDK repository (which needs to be compiled as well), same results in terms of linker errors.

By applying changes in this PR, it compiles fine on my side.