### PR TITLE
Updated documentation for glslang checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You'll also need glslLang inorder to compile GLSL shaders to Vulkan compatible S
 
     git clone https://github.com/KhronosGroup/glslang.git
     cd ./glsllang
+    ./update_glslang_sources.py
     cmake . -G "Visual Studio 15 2017 Win64"
     
 Open the generated Visual Studio solution file (Ensure you start Visual Studi as Admin if installing to the default location). Build install target for debug and release and finally add the install location (default C:\Program Files\glslang) to CMAKE_PREFIX_PATH environment variable.


### PR DESCRIPTION
Call to `./update_glslang_sources.py` is required due to
```bash
https://github.com/vsg-dev/osg2vsg/commit/f819545775d9883c6f9d822a32f59d4aaa1a56d2
```