### PR TITLE
Multi Texturing and Normal mapping

### DIFF
--- a/include/osg2vsg/GeometryUtils.h
+++ b/include/osg2vsg/GeometryUtils.h
@@ -14,20 +14,22 @@ namespace osg2vsg
     {
         VERTEX = 1,
         NORMAL = 2,
-        COLOR = 4,
-        TEXCOORD0 = 8,
-        TEXCOORD1 = 16,
-        TEXCOORD2 = 32,
+        TANGENT = 4,
+        COLOR = 8,
+        TEXCOORD0 = 16,
+        TEXCOORD1 = 32,
+        TEXCOORD2 = 64,
         STANDARD_ATTS = VERTEX | NORMAL | COLOR | TEXCOORD0,
-        ALL_ATTS = VERTEX | NORMAL | COLOR | TEXCOORD0 | TEXCOORD1 | TEXCOORD2
+        ALL_ATTS = VERTEX | NORMAL | COLOR | TEXCOORD0 | TEXCOORD1 | TEXCOORD2 | TANGENT
     };
 
     enum AttributeChannels
     {
-        VERTEX_CHANNEL = 0,
-        NORMAL_CHANNEL = 1,
-        COLOR_CHANNEL = 2,
-        TEXCOORD0_CHANNEL = 3,
+        VERTEX_CHANNEL = 0,  // osg 0
+        NORMAL_CHANNEL = 1, // osg 1
+        TANGENT_CHANNEL = 2, //osg 6
+        COLOR_CHANNEL = 3, // osg 2
+        TEXCOORD0_CHANNEL = 4, //osg 3
         TEXCOORD1_CHANNEL = TEXCOORD0_CHANNEL + 1,
         TEXCOORD2_CHANNEL = TEXCOORD0_CHANNEL + 2,
     };
@@ -50,8 +52,12 @@ namespace osg2vsg
 
     extern OSG2VSG_DECLSPEC VkSamplerCreateInfo convertToSamplerCreateInfo(const osg::Texture* texture);
 
+    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::Texture> convertToVsg(const osg::Texture* osgtexture);
+
+    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::AttributesNode> createTextureAttributesNode(const osg::StateSet* stateset);
+
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::Geometry> convertToVsg(osg::Geometry* geometry, uint32_t requiredAttributesMask = 0);
 
-    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::GraphicsPipelineGroup> createGeometryGraphicsPipeline(const uint32_t& geometryAttributesMask, const uint32_t& stateMask, unsigned int maxNumDescriptors);
+    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::GraphicsPipelineGroup> createGeometryGraphicsPipeline(const uint32_t& shaderModeMask, const uint32_t& geometryAttributesMask, unsigned int maxNumDescriptors);
 
 }

--- a/include/osg2vsg/GraphicsNodes.h
+++ b/include/osg2vsg/GraphicsNodes.h
@@ -149,7 +149,7 @@ namespace vsg
 
         // experimental
         uint32_t _bindingIndex = 0;
-        ref_ptr<Sampler> _sampler;
+        VkSamplerCreateInfo _samplerInfo;
     };
     VSG_type_name(vsg::Texture)
 
@@ -186,4 +186,55 @@ namespace vsg
         ref_ptr<Group> _renderImplementation;
     };
     VSG_type_name(vsg::Geometry)
+
+    class Attribute : public Inherit<Object, Attribute>
+    {
+    public:
+        Attribute(Allocator* allocator = nullptr);
+
+        void read(Input& input) override;
+        void write(Output& output) const override;
+
+        virtual void compile(Context& context) = 0;
+
+        ref_ptr<vsg::Descriptor> _descriptor;
+        uint32_t _bindingIndex = 0;
+    };
+    VSG_type_name(vsg::Attribute)
+
+    class TextureAttribute : public Inherit<Attribute, TextureAttribute>
+    {
+    public:
+        TextureAttribute(Allocator* allocator = nullptr);
+
+        void compile(Context& context) override;
+
+        ref_ptr<Data> _textureData;
+        VkSamplerCreateInfo _samplerInfo;
+    };
+    VSG_type_name(vsg::TextureAttribute)
+
+    class AttributesNode : public Inherit<GraphicsNode, AttributesNode>
+    {
+    public:
+        AttributesNode(Allocator* allocator = nullptr);
+
+        using Inherit::traverse;
+
+        void traverse(Visitor& visitor) override;
+        void traverse(ConstVisitor& visitor) const override;
+
+        void accept(DispatchTraversal& dv) const override;
+
+        void read(Input& input) override;
+        void write(Output& output) const override;
+
+        void compile(Context& context) override;
+
+        ref_ptr<vsg::BindDescriptorSets> _bindDescriptorSets;
+
+        using AttributesList = std::vector<ref_ptr<Attribute>>;
+        AttributesList _attributesList;
+    };
+    VSG_type_name(vsg::AttributesNode)
 }

--- a/include/osg2vsg/ShaderUtils.h
+++ b/include/osg2vsg/ShaderUtils.h
@@ -10,12 +10,12 @@
 
 namespace osg2vsg
 {
-    enum StateMask
+    enum ShaderModeMask
     {
         NONE = 0,
         LIGHTING = 1,
-        DIFFUSE_MAP = 2, //< Texture in unit 0
-        NORMAL_MAP = 4  //< Texture in unit 1 and tangent vector array in index 6
+        DIFFUSE_MAP = 2,
+        NORMAL_MAP = 4 
     };
 
     // taken from osg fbx plugin
@@ -31,12 +31,12 @@ namespace osg2vsg
         SHININESS_TEXTURE_UNIT
     };
 
-    extern OSG2VSG_DECLSPEC uint32_t calculateStateMask(osg::StateSet* stateSet);
+    extern OSG2VSG_DECLSPEC uint32_t calculateShaderModeMask(osg::StateSet* stateSet);
 
     // create vertex shader source using statemask to determine type of shader to build and geometryattributes to determine attribute binding locations
-    extern OSG2VSG_DECLSPEC std::string createVertexSource(const uint32_t& stateMask, const uint32_t& geometryAttrbutes, bool osgCompatible);
+    extern OSG2VSG_DECLSPEC std::string createVertexSource(const uint32_t& shaderModeMask, const uint32_t& geometryAttrbutes, bool osgCompatible);
 
-    extern OSG2VSG_DECLSPEC std::string createFragmentSource(const uint32_t& stateMask, const uint32_t& geometryAttrbutes, bool osgCompatible);
+    extern OSG2VSG_DECLSPEC std::string createFragmentSource(const uint32_t& shaderModeMask, const uint32_t& geometryAttrbutes, bool osgCompatible);
 
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::Shader> compileSourceToSPV(const std::string& source, bool isvert);
 


### PR DESCRIPTION
Big commit here, this adds support for Normal mapping. I've refactored the shader gen and geometry mask enums . Cleaned up a bit.

The big change is the inclusion of AttributesNode, Attribute and TextureAttrbute. This has been added to aid multi texturing.

The AttributesNode stores a list of Attributes and creates the vsg::BindDescriptorSets, when it's compiled each of it's Attribute objects are compiled. Each of the those creates a Descriptor (DescriptorImage in the case of the TextureAttribute).

Am also generating tangents for Normal mapping with osgUtil::TangentSpaceGenerator. I'll send you a screen shot.

I think this is roughly the right direction to head, we could also add a UniformAttribute perhaps.