### PR TITLE
Allow multiple descriptor set layouts, SharedBindDescriptorSets

### DIFF
--- a/include/osg2vsg/GraphicsNodes.h
+++ b/include/osg2vsg/GraphicsNodes.h
@@ -37,7 +37,7 @@ namespace vsg
         uint32_t maxSets = 0;
         DescriptorPoolSizes descriptorPoolSizes; // need to accumulate descriptorPoolSizes by looking at scene graph
         // descriptorSetLayout ..
-        DescriptorSetLayoutBindings descriptorSetLayoutBindings;
+        std::vector<DescriptorSetLayoutBindings> descriptorSetLayoutBindings;
         PushConstantRanges pushConstantRanges;
         VertexInputState::Bindings vertexBindingsDescriptions;
         VertexInputState::Attributes vertexAttributeDescriptions;

--- a/include/osg2vsg/ShaderUtils.h
+++ b/include/osg2vsg/ShaderUtils.h
@@ -19,7 +19,7 @@ namespace osg2vsg
         AMBIENT_MAP = 8,
         NORMAL_MAP = 16,
         SPECULAR_MAP = 32,
-        ALL_SHADER_MODE_MASK = LIGHTING | DIFFUSE_MAP | OPACITY_MAP | AMBIENT_MAP | SPECULAR_MAP
+        ALL_SHADER_MODE_MASK = LIGHTING | DIFFUSE_MAP | OPACITY_MAP | AMBIENT_MAP | NORMAL_MAP | SPECULAR_MAP
     };
 
     // taken from osg fbx plugin

--- a/include/osg2vsg/StateAttributes.h
+++ b/include/osg2vsg/StateAttributes.h
@@ -36,7 +36,7 @@ namespace vsg
         uint32_t maxSets = 0;
         DescriptorPoolSizes descriptorPoolSizes; // need to accumulate descriptorPoolSizes by looking at scene graph
         // descriptorSetLayout ..
-        DescriptorSetLayoutBindings descriptorSetLayoutBindings;
+        std::vector<DescriptorSetLayoutBindings> descriptorSetLayoutBindings;
         PushConstantRanges pushConstantRanges;
         VertexInputState::Bindings vertexBindingsDescriptions;
         VertexInputState::Attributes vertexAttributeDescriptions;

--- a/src/osg2vsg/GeometryUtils.cpp
+++ b/src/osg2vsg/GeometryUtils.cpp
@@ -360,7 +360,7 @@ namespace osg2vsg
         if (shaderModeMask & NORMAL_MAP) descriptorBindings.push_back( { NORMAL_TEXTURE_UNIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr });
         if (shaderModeMask & SPECULAR_MAP) descriptorBindings.push_back( { SPECULAR_TEXTURE_UNIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr });
 
-        gp->descriptorSetLayoutBindings = descriptorBindings;
+        gp->descriptorSetLayoutBindings.push_back(descriptorBindings);
 
         vsg::DescriptorPoolSizes descriptorPoolSizes = vsg::DescriptorPoolSizes();
 
@@ -529,7 +529,7 @@ namespace osg2vsg
         if (shaderModeMask & DIFFUSE_MAP) descriptorBindings.push_back( { 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr } );
         if (shaderModeMask & NORMAL_MAP) descriptorBindings.push_back( { 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr  } );
 
-        gp->descriptorSetLayoutBindings = descriptorBindings;
+        gp->descriptorSetLayoutBindings.push_back(descriptorBindings);
 
         gp->pushConstantRanges = vsg::PushConstantRanges
         {

--- a/src/osg2vsg/GeometryUtils.cpp
+++ b/src/osg2vsg/GeometryUtils.cpp
@@ -453,6 +453,8 @@ namespace osg2vsg
 
         auto vsg_stateset = vsg::StateSet::create();
 
+        vsg::ref_ptr<vsg::SharedBindDescriptorSets> sharedDescriptorSetBinding = vsg::SharedBindDescriptorSets::create();
+
         unsigned int units = stateset->getNumTextureAttributeLists();
         uint32_t texcount = 0;
 
@@ -467,6 +469,12 @@ namespace osg2vsg
                 {
                     // shaders are looking for textures in original units
                     vsgtex->_bindingIndex = i;
+                    // use a shared descriptor set binding
+                    if (sharedDescriptorSetBinding.valid())
+                    {
+                        vsgtex->_ownsBindDescriptorSets = false;
+                        vsgtex->_bindDescriptorSets = sharedDescriptorSetBinding;
+                    }
                     texcount++; //
                     vsg_stateset->add(vsgtex);
                 }
@@ -484,6 +492,9 @@ namespace osg2vsg
         if (shaderModeMask & ShaderModeMask::SPECULAR_MAP) addTexture(SPECULAR_TEXTURE_UNIT);
 
         if (texcount==0) return vsg::ref_ptr<vsg::StateSet>();
+
+        // add the shared binding at the end so that the textures will compile first and add their descriptors to the shared binding
+        if(sharedDescriptorSetBinding.valid()) vsg_stateset->add(sharedDescriptorSetBinding);
 
         return vsg_stateset;
     }

--- a/src/osg2vsg/GeometryUtils.cpp
+++ b/src/osg2vsg/GeometryUtils.cpp
@@ -349,7 +349,7 @@ namespace osg2vsg
         //
         vsg::ref_ptr<vsg::GraphicsPipelineGroup> gp = vsg::GraphicsPipelineGroup::create();
         gp->shaders = shaders;
-        gp->maxSets = std::max<unsigned int>(maxNumDescriptors, 1);
+        gp->maxSets = std::max<unsigned int>(maxNumDescriptors, 1); // total sets
 
         vsg::DescriptorSetLayoutBindings descriptorBindings  = vsg::DescriptorSetLayoutBindings();
 
@@ -366,7 +366,7 @@ namespace osg2vsg
 
         if (descriptorBindings.size() > 0)
         {
-            descriptorPoolSizes.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, static_cast<uint32_t>(descriptorBindings.size()) }); // type, descriptorCount
+            descriptorPoolSizes.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, static_cast<uint32_t>(descriptorBindings.size()) }); // type, descriptorCount // total descriptors of a type across all sets
         };
 
         gp->descriptorPoolSizes = descriptorPoolSizes;
@@ -465,7 +465,9 @@ namespace osg2vsg
                 vsg::ref_ptr<vsg::Texture> vsgtex = convertToVsgTexture(osgtex);
                 if (vsgtex)
                 {
-                    vsgtex->_bindingIndex = texcount++; // i
+                    // shaders are looking for textures in original units
+                    vsgtex->_bindingIndex = i;
+                    texcount++; //
                     vsg_stateset->add(vsgtex);
                 }
                 else
@@ -510,13 +512,13 @@ namespace osg2vsg
         //
         vsg::ref_ptr<vsg::GraphicsPipelineAttribute> gp = vsg::GraphicsPipelineAttribute::create();
         gp->shaders = shaders;
-        gp->maxSets = maxNumDescriptors;
+        gp->maxSets = maxNumDescriptors; //  total sets
 
         if (maxNumDescriptors > 0)
         {
             gp->descriptorPoolSizes = vsg::DescriptorPoolSizes
             {
-                {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, maxNumDescriptors} // type, descriptorCount
+                {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, maxNumDescriptors} // type, descriptorCount // total descriptors of a type across all sets
             };
         }
 
@@ -525,9 +527,13 @@ namespace osg2vsg
 
         vsg::DescriptorSetLayoutBindings descriptorBindings;
 
+        // these need to go in incremental order by texture unit value as that how they will have been added to the desctiptor set
         // VkDescriptorSetLayoutBinding { binding, descriptorTpe, descriptorCount, stageFlags, pImmutableSamplers}
-        if (shaderModeMask & DIFFUSE_MAP) descriptorBindings.push_back( { 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr } );
-        if (shaderModeMask & NORMAL_MAP) descriptorBindings.push_back( { 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr  } );
+        if (shaderModeMask & DIFFUSE_MAP) descriptorBindings.push_back({ DIFFUSE_TEXTURE_UNIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr }); // { binding, descriptorTpe, descriptorCount, stageFlags, pImmutableSamplers}
+        if (shaderModeMask & OPACITY_MAP) descriptorBindings.push_back({ OPACITY_TEXTURE_UNIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr });
+        if (shaderModeMask & AMBIENT_MAP) descriptorBindings.push_back({ AMBIENT_TEXTURE_UNIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr });
+        if (shaderModeMask & NORMAL_MAP) descriptorBindings.push_back({ NORMAL_TEXTURE_UNIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr });
+        if (shaderModeMask & SPECULAR_MAP) descriptorBindings.push_back({ SPECULAR_TEXTURE_UNIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr });
 
         gp->descriptorSetLayoutBindings.push_back(descriptorBindings);
 

--- a/src/osg2vsg/GraphicsNodes.cpp
+++ b/src/osg2vsg/GraphicsNodes.cpp
@@ -93,10 +93,13 @@ void GraphicsPipelineGroup::compile(Context& context)
     context.descriptorPool = DescriptorPool::create(context.device, maxSets, descriptorPoolSizes);
     DEBUG_OUTPUT<<"  context.descriptorPool = "<<context.descriptorPool.get()<<std::endl;
 
-    context.descriptorSetLayout = DescriptorSetLayout::create(context.device, descriptorSetLayoutBindings);
-    DEBUG_OUTPUT<<"  context.descriptorSetLayout = "<<context.descriptorSetLayout.get()<<std::endl;
+    for (unsigned int i = 0; i < descriptorSetLayoutBindings.size(); i++)
+    {
+        context.descriptorSetLayouts.push_back(DescriptorSetLayout::create(context.device, descriptorSetLayoutBindings[i]));
+        DEBUG_OUTPUT << "  context.descriptorSetLayout = " << context.descriptorSetLayouts[i].get() << std::endl;
+    }
 
-    context.pipelineLayout = PipelineLayout::create(context.device, {context.descriptorSetLayout}, pushConstantRanges);
+    context.pipelineLayout = PipelineLayout::create(context.device, context.descriptorSetLayouts, pushConstantRanges);
     DEBUG_OUTPUT<<"  context.pipelineLayout = "<<context.pipelineLayout.get()<<std::endl;
 
 
@@ -243,7 +246,7 @@ void AttributesNode::compile(Context& context)
         }
     }
 
-    vsg::ref_ptr<vsg::DescriptorSet> descriptorSet = vsg::DescriptorSet::create(context.device, context.descriptorPool, context.descriptorSetLayout, attributeDescriptors);
+    vsg::ref_ptr<vsg::DescriptorSet> descriptorSet = vsg::DescriptorSet::create(context.device, context.descriptorPool, context.descriptorSetLayouts[0], attributeDescriptors);
 
     if (descriptorSet)
     {

--- a/src/osg2vsg/SceneAnalysisVisitor.cpp
+++ b/src/osg2vsg/SceneAnalysisVisitor.cpp
@@ -450,6 +450,7 @@ vsg::ref_ptr<vsg::Node> SceneAnalysisVisitor::createCoreVSG(vsg::Paths& searchPa
 
         uint32_t geometrymask = (masks.second | overrideGeomAttributes) & supportedGeometryAttributes;
         uint32_t shaderModeMask = (masks.first | overrideShaderModeMask) & supportedShaderModeMask;
+        if (shaderModeMask & NORMAL_MAP) geometrymask |= TANGENT; // mesh propably won't have tangets so force them on if we want Normal mapping
 
         std::cout<<"  about to call createStateSetWithGraphicsPipeline("<<shaderModeMask<<", "<<geometrymask<<", "<<maxNumDescriptors<<")"<<std::endl;
 

--- a/src/osg2vsg/StateAttributes.cpp
+++ b/src/osg2vsg/StateAttributes.cpp
@@ -85,10 +85,13 @@ void GraphicsPipelineAttribute::compile(Context& context)
     if (!descriptorPoolSizes.empty()) context.descriptorPool = DescriptorPool::create(context.device, maxSets, descriptorPoolSizes);
     DEBUG_OUTPUT<<"  context.descriptorPool = "<<context.descriptorPool.get()<<std::endl;
 
-    context.descriptorSetLayout = DescriptorSetLayout::create(context.device, descriptorSetLayoutBindings);
-    DEBUG_OUTPUT<<"  context.descriptorSetLayout = "<<context.descriptorSetLayout.get()<<std::endl;
+    for (unsigned int i = 0; i < descriptorSetLayoutBindings.size(); i++)
+    {
+        context.descriptorSetLayouts.push_back(DescriptorSetLayout::create(context.device, descriptorSetLayoutBindings[i]));
+        DEBUG_OUTPUT << "  context.descriptorSetLayout = " << context.descriptorSetLayouts[i].get() << std::endl;
+    }
 
-    context.pipelineLayout = PipelineLayout::create(context.device, {context.descriptorSetLayout}, pushConstantRanges);
+    context.pipelineLayout = PipelineLayout::create(context.device, context.descriptorSetLayouts, pushConstantRanges);
     DEBUG_OUTPUT<<"  context.pipelineLayout = "<<context.pipelineLayout.get()<<std::endl;
 
 
@@ -161,7 +164,7 @@ void Texture::compile(Context& context)
     }
 
     // set up DescriptorSet
-    vsg::ref_ptr<vsg::DescriptorSet> descriptorSet = vsg::DescriptorSet::create(context.device, context.descriptorPool, context.descriptorSetLayout,
+    vsg::ref_ptr<vsg::DescriptorSet> descriptorSet = vsg::DescriptorSet::create(context.device, context.descriptorPool, context.descriptorSetLayouts[0],
     {
         vsg::DescriptorImage::create(_bindingIndex, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, vsg::ImageDataList{imageData})
     });


### PR DESCRIPTION
I've made a simpler demonstration of the issue I think we have.

So currently a texture makes a descriptor, creates a set using that descriptor then creates a bindDescriptorSets using that set. The textures are using a different bindingindex

However when you add another texture with a different binding index you end up eliminating the fist because each texture makes another bindDescriptorSets that only contains one set. 

I'm pretty sure the call to vkCmdBindDescriptorSets will replace any exisitng set in the same index/setnumber.

To have multiple descriptors within a single set we must bind them in the same call. If we want multiple sets each with it's own BindDescriptorSets then I think we need to change the vkCmdBindDescriptorSets call to account for firstSet index. Currently if we have two BindDescriptorSets with one set in each one will replace the other. If we allowed a firstSet index for the BindDescriptorSets then one texture could bind to set 0, another to set 1 etc.
The example just creates a ShareBindDescriptorSets, that is passed to the texture and it's descriptor is added to a list during compile. We then add the ShareBindDescriptorSets to the stateset after the textures so once the textures have compiled and added their descriptors the ShareBindDescriptorSets can compile all the descriptors into DescriptorSets and bind them.

It's still a hack but i think it gets the idea across. Hope that makes sense, think how this gets handled is gonna be pretty critical. Perhaps we should even try adding in a more generic uniform before we commit to anything, try and understand all the requirements.

Note the ShareBindDescriptorSets is currently active, to disable it just change line 456 of GeometryUtils.cpp so that there isn't a vaild ShareBindDescriptorSets.
