### PR TITLE
Support to load custom vert and frag program with --vert and --frag arguments

### DIFF
--- a/applications/osg2vsg/osg2vsg.cpp
+++ b/applications/osg2vsg/osg2vsg.cpp
@@ -127,6 +127,9 @@ int main(int argc, char** argv)
     arguments.read({"--window", "-w"}, windowTraits->width, windowTraits->height);
     arguments.read({"--support-mask", "--sm"}, sceneAnalysis.supportedShaderModeMask);
     arguments.read({"--override-mask", "--om"}, sceneAnalysis.overrideShaderModeMask);
+    arguments.read({ "--vertex-shader", "--vert" }, sceneAnalysis.vertexShaderPath);
+    arguments.read({ "--fragment-shader", "--frag" }, sceneAnalysis.fragmentShaderPath);
+
     if (arguments.errors()) return arguments.writeErrorMessages(std::cerr);
 
     // read shaders

--- a/data/shaders/fbxshader.frag
+++ b/data/shaders/fbxshader.frag
@@ -1,0 +1,81 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+layout(binding = 0) uniform sampler2D diffuseMap;
+#endif
+#ifdef VSG_OPACITY_MAP
+layout(binding = 1) uniform sampler2D opacityMap;
+#endif
+#ifdef VSG_AMBIENT_MAP
+layout(binding = 4) uniform sampler2D ambientMap;
+#endif
+#ifdef VSG_NORMAL_MAP
+layout(binding = 5) uniform sampler2D normalMap;
+#endif
+#ifdef VSG_SPECULAR_MAP
+layout(binding = 6) uniform sampler2D specularMap;
+#endif
+#ifdef VSG_NORMAL
+layout(location = 1) in vec3 normalDir;
+#endif
+#ifdef VSG_COLOR
+layout(location = 3) in vec4 vertColor;
+#endif
+#ifdef VSG_TEXCOORD0
+layout(location = 4) in vec2 texCoord0;
+#endif
+#ifdef VSG_LIGHTING
+layout(location = 5) in vec3 viewDir;
+layout(location = 6) in vec3 lightDir;
+#endif
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+#ifdef VSG_DIFFUSE_MAP
+    vec4 base = texture(diffuseMap, texCoord0.st);
+#else
+    vec4 base = vec4(1.0,1.0,1.0,1.0);
+#endif
+#ifdef VSG_COLOR
+    base = base * vertColor;
+#endif
+#ifdef VSG_AMBIENT_MAP
+    float ambientOcclusion = texture(ambientMap, texCoord0.st).r;
+#else
+    float ambientOcclusion = 1.0;
+#endif
+#ifdef VSG_SPECULAR_MAP
+    vec3 specularColor = texture(specularMap, texCoord0.st).rgb;
+#else
+    vec3 specularColor = vec3(0.2,0.2,0.2);
+#endif
+#ifdef VSG_LIGHTING
+#ifdef VSG_NORMAL_MAP
+    vec3 nDir = texture(normalMap, texCoord0.st).xyz*2.0 - 1.0;
+    nDir.g = -nDir.g;
+#else
+    vec3 nDir = normalDir;
+#endif
+    vec3 nd = normalize(nDir);
+    vec3 ld = normalize(lightDir);
+    vec3 vd = normalize(viewDir);
+    vec4 color = vec4(0.01, 0.01, 0.01, 1.0);
+    color += /*osg_Material.ambient*/ vec4(0.1, 0.1, 0.1, 0.0);
+    float diff = max(dot(ld, nd), 0.0);
+    color += /*osg_Material.diffuse*/ vec4(0.8, 0.8, 0.8, 0.0) * diff;
+    color *= ambientOcclusion;
+    color *= base;
+    if (diff > 0.0)
+    {
+        vec3 halfDir = normalize(ld + vd);
+        color.rgb += base.a * specularColor *
+            pow(max(dot(halfDir, nd), 0.0), 16.0/*osg_Material.shine*/);
+    }
+#else
+    vec4 color = base;
+#endif
+    outColor = color;
+#ifdef VSG_OPACITY_MAP
+    outColor.a *= texture(opacityMap, texCoord0.st).r;
+#endif
+}

--- a/data/shaders/fbxshader.frag
+++ b/data/shaders/fbxshader.frag
@@ -1,5 +1,7 @@
 #version 450
+#pragma import_defines ( VSG_NORMAL, VSG_COLOR, VSG_TEXCOORD0, VSG_LIGHTING, VSG_DIFFUSE_MAP, VSG_OPACITY_MAP, VSG_AMBIENT_MAP, VSG_NORMAL_MAP, VSG_SPECULAR_MAP )
 #extension GL_ARB_separate_shader_objects : enable
+#ifdef VSG_DIFFUSE_MAP
 layout(binding = 0) uniform sampler2D diffuseMap;
 #endif
 #ifdef VSG_OPACITY_MAP

--- a/data/shaders/fbxshader.vert
+++ b/data/shaders/fbxshader.vert
@@ -1,4 +1,5 @@
 #version 450
+#pragma import_defines ( VSG_NORMAL, VSG_TANGENT, VSG_COLOR, VSG_TEXCOORD0, VSG_LIGHTING, VSG_NORMAL_MAP )
 #extension GL_ARB_separate_shader_objects : enable
 layout(push_constant) uniform PushConstants {
     mat4 projection;

--- a/data/shaders/fbxshader.vert
+++ b/data/shaders/fbxshader.vert
@@ -1,0 +1,68 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+layout(push_constant) uniform PushConstants {
+    mat4 projection;
+    mat4 view;
+    mat4 model;
+    //mat3 normal;
+} pc;
+layout(location = 0) in vec3 osg_Vertex;
+#ifdef VSG_NORMAL
+layout(location = 1) in vec3 osg_Normal;
+layout(location = 1) out vec3 normalDir;
+#endif
+#ifdef VSG_TANGENT
+layout(location = 2) in vec4 osg_Tangent;
+#endif
+#ifdef VSG_COLOR
+layout(location = 3) in vec4 osg_Color;
+layout(location = 3) out vec4 vertColor;
+#endif
+#ifdef VSG_TEXCOORD0
+layout(location = 4) in vec2 osg_MultiTexCoord0;
+layout(location = 4) out vec2 texCoord0;
+#endif
+#ifdef VSG_LIGHTING
+layout(location = 5) out vec3 viewDir;
+layout(location = 6) out vec3 lightDir;
+#endif
+out gl_PerVertex{ vec4 gl_Position; };
+
+void main()
+{
+    gl_Position = (pc.projection * pc.view * pc.model) * vec4(osg_Vertex, 1.0);
+#ifdef VSG_TEXCOORD0
+    texCoord0 = osg_MultiTexCoord0.st;
+#endif
+#ifdef VSG_NORMAL
+    vec3 n = ((pc.view * pc.model) * vec4(osg_Normal, 0.0)).xyz;
+    normalDir = n;
+#endif
+#ifdef VSG_LIGHTING
+    vec4 lpos = /*osg_LightSource.position*/ vec4(0.0, 0.25, 1.0, 0.0);
+#ifdef VSG_NORMAL_MAP
+    vec3 t = ((pc.view * pc.model) * vec4(osg_Tangent.xyz, 0.0)).xyz;
+    vec3 b = cross(n, t);
+    vec3 dir = -vec3((pc.view * pc.model) * vec4(osg_Vertex, 1.0));
+    viewDir.x = dot(dir, t);
+    viewDir.y = dot(dir, b);
+    viewDir.z = dot(dir, n);
+    if (lpos.w == 0.0)
+        dir = lpos.xyz;
+    else
+        dir += lpos.xyz;
+    lightDir.x = dot(dir, t);
+    lightDir.y = dot(dir, b);
+    lightDir.z = dot(dir, n);
+#else
+    viewDir = -vec3((pc.view * pc.model) * vec4(osg_Vertex, 1.0));
+    if (lpos.w == 0.0)
+        lightDir = lpos.xyz;
+    else
+        lightDir = lpos.xyz + viewDir;
+#endif
+#endif
+#ifdef VSG_COLOR
+    vertColor = osg_Color;
+#endif
+}

--- a/include/osg2vsg/GeometryUtils.h
+++ b/include/osg2vsg/GeometryUtils.h
@@ -57,12 +57,12 @@ namespace osg2vsg
 
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::Geometry> convertToVsg(osg::Geometry* geometry, uint32_t requiredAttributesMask = 0);
 
-    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::GraphicsPipelineGroup> createGeometryGraphicsPipeline(const uint32_t& shaderModeMask, const uint32_t& geometryAttributesMask, unsigned int maxNumDescriptors);
+    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::GraphicsPipelineGroup> createGeometryGraphicsPipeline(const uint32_t& shaderModeMask, const uint32_t& geometryAttributesMask, unsigned int maxNumDescriptors, const std::string& vertShaderPath = "", const std::string& fragShaderPath = "");
 
 
     // core VSG style usage
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::Texture> convertToVsgTexture(const osg::Texture* osgtexture);
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::StateSet> createVsgStateSet(const osg::StateSet* stateset, uint32_t shaderModeMask);
-    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::StateSet> createStateSetWithGraphicsPipeline(uint32_t shaderModeMask, uint32_t geometryAttributesMask, unsigned int maxNumDescriptors);
+    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::StateSet> createStateSetWithGraphicsPipeline(uint32_t shaderModeMask, uint32_t geometryAttributesMask, unsigned int maxNumDescriptors, const std::string& vertShaderPath = "", const std::string& fragShaderPath = "");
 
 }

--- a/include/osg2vsg/SceneAnalysisVisitor.h
+++ b/include/osg2vsg/SceneAnalysisVisitor.h
@@ -70,6 +70,9 @@ namespace osg2vsg
         uint32_t overrideGeomAttributes = GeometryAttributes::STANDARD_ATTS;
         uint32_t overrideShaderModeMask = ShaderModeMask::NONE;
 
+        std::string vertexShaderPath = "";
+        std::string fragmentShaderPath = "";
+
         osg::ref_ptr<osg::StateSet> uniqueState(osg::ref_ptr<osg::StateSet> stateset, bool programStateSet);
 
         StatePair computeStatePair(osg::StateSet* stateset);

--- a/include/osg2vsg/ShaderUtils.h
+++ b/include/osg2vsg/ShaderUtils.h
@@ -37,6 +37,9 @@ namespace osg2vsg
 
     extern OSG2VSG_DECLSPEC uint32_t calculateShaderModeMask(osg::StateSet* stateSet);
 
+    // read a glsl file and inject defines based on shadermodemask and geometryatts
+    extern OSG2VSG_DECLSPEC std::string readGLSLShader(const std::string& filename, const uint32_t& shaderModeMask, const uint32_t& geometryAttrbutes);
+
     // create vertex shader source using statemask to determine type of shader to build and geometryattributes to determine attribute binding locations
     extern OSG2VSG_DECLSPEC std::string createVertexSource(const uint32_t& shaderModeMask, const uint32_t& geometryAttrbutes);
 

--- a/src/osg2vsg/GeometryUtils.cpp
+++ b/src/osg2vsg/GeometryUtils.cpp
@@ -330,7 +330,7 @@ namespace osg2vsg
         return geometry;
     }
 
-    vsg::ref_ptr<vsg::GraphicsPipelineGroup> createGeometryGraphicsPipeline(const uint32_t& shaderModeMask, const uint32_t& geometryAttributesMask, unsigned int maxNumDescriptors)
+    vsg::ref_ptr<vsg::GraphicsPipelineGroup> createGeometryGraphicsPipeline(const uint32_t& shaderModeMask, const uint32_t& geometryAttributesMask, unsigned int maxNumDescriptors, const std::string& vertShaderPath, const std::string& fragShaderPath)
     {
         //
         // load shaders
@@ -338,8 +338,8 @@ namespace osg2vsg
         ShaderCompiler shaderCompiler;
 
         vsg::GraphicsPipelineGroup::Shaders shaders{
-            vsg::Shader::create(VK_SHADER_STAGE_VERTEX_BIT, "main", createVertexSource(shaderModeMask, geometryAttributesMask)),
-            vsg::Shader::create(VK_SHADER_STAGE_FRAGMENT_BIT, "main", createFragmentSource(shaderModeMask, geometryAttributesMask)),
+            vsg::Shader::create(VK_SHADER_STAGE_VERTEX_BIT, "main", vertShaderPath.empty() ? createVertexSource(shaderModeMask, geometryAttributesMask) : readGLSLShader(vertShaderPath, shaderModeMask, geometryAttributesMask)),
+            vsg::Shader::create(VK_SHADER_STAGE_FRAGMENT_BIT, "main", fragShaderPath.empty() ? createFragmentSource(shaderModeMask, geometryAttributesMask) : readGLSLShader(fragShaderPath, shaderModeMask, geometryAttributesMask))
         };
 
         if (!shaderCompiler.compile(shaders)) return vsg::ref_ptr<vsg::GraphicsPipelineGroup>();
@@ -500,7 +500,7 @@ namespace osg2vsg
     }
 
 
-    vsg::ref_ptr<vsg::StateSet> createStateSetWithGraphicsPipeline(uint32_t shaderModeMask, uint32_t geometryAttributesMask, unsigned int maxNumDescriptors)
+    vsg::ref_ptr<vsg::StateSet> createStateSetWithGraphicsPipeline(uint32_t shaderModeMask, uint32_t geometryAttributesMask, unsigned int maxNumDescriptors, const std::string& vertShaderPath, const std::string& fragShaderPath)
     {
         auto stateset = vsg::StateSet::create();
         //
@@ -509,8 +509,8 @@ namespace osg2vsg
         ShaderCompiler shaderCompiler;
 
         vsg::GraphicsPipelineAttribute::Shaders shaders{
-            vsg::Shader::create(VK_SHADER_STAGE_VERTEX_BIT, "main", createVertexSource(shaderModeMask, geometryAttributesMask)),
-            vsg::Shader::create(VK_SHADER_STAGE_FRAGMENT_BIT, "main", createFragmentSource(shaderModeMask, geometryAttributesMask)),
+            vsg::Shader::create(VK_SHADER_STAGE_VERTEX_BIT, "main", vertShaderPath.empty() ? createVertexSource(shaderModeMask, geometryAttributesMask) : readGLSLShader(vertShaderPath, shaderModeMask, geometryAttributesMask)),
+            vsg::Shader::create(VK_SHADER_STAGE_FRAGMENT_BIT, "main", fragShaderPath.empty() ? createFragmentSource(shaderModeMask, geometryAttributesMask) : readGLSLShader(fragShaderPath, shaderModeMask, geometryAttributesMask))
         };
 
         if (!shaderCompiler.compile(shaders)) return vsg::ref_ptr<vsg::StateSet>();

--- a/src/osg2vsg/GraphicsNodes.cpp
+++ b/src/osg2vsg/GraphicsNodes.cpp
@@ -93,6 +93,9 @@ void GraphicsPipelineGroup::compile(Context& context)
     context.descriptorPool = DescriptorPool::create(context.device, maxSets, descriptorPoolSizes);
     DEBUG_OUTPUT<<"  context.descriptorPool = "<<context.descriptorPool.get()<<std::endl;
 
+    // prevent previous GraphicsPipelineAttribute::compile(Context& context) calls during the current compile traversal accumulating into this GraphicsPipeline setup.
+    context.descriptorSetLayouts.clear();
+
     for (unsigned int i = 0; i < descriptorSetLayoutBindings.size(); i++)
     {
         context.descriptorSetLayouts.push_back(DescriptorSetLayout::create(context.device, descriptorSetLayoutBindings[i]));

--- a/src/osg2vsg/SceneAnalysisVisitor.cpp
+++ b/src/osg2vsg/SceneAnalysisVisitor.cpp
@@ -405,7 +405,7 @@ vsg::ref_ptr<vsg::Node> SceneAnalysisVisitor::createNewVSG(vsg::Paths& searchPat
 
         unsigned int maxNumDescriptors = transformStatePair.stateTransformMap.size();
 
-        auto graphicsPipelineGroup = createGeometryGraphicsPipeline(shaderModeMask, geometrymask, maxNumDescriptors);
+        auto graphicsPipelineGroup = createGeometryGraphicsPipeline(shaderModeMask, geometrymask, maxNumDescriptors, vertexShaderPath, fragmentShaderPath);
 
         group->addChild(graphicsPipelineGroup);
 
@@ -454,7 +454,7 @@ vsg::ref_ptr<vsg::Node> SceneAnalysisVisitor::createCoreVSG(vsg::Paths& searchPa
 
         std::cout<<"  about to call createStateSetWithGraphicsPipeline("<<shaderModeMask<<", "<<geometrymask<<", "<<maxNumDescriptors<<")"<<std::endl;
 
-        auto graphicsPipelineGroup = vsg::StateGroup::create(createStateSetWithGraphicsPipeline(shaderModeMask, geometrymask, maxNumDescriptors));
+        auto graphicsPipelineGroup = vsg::StateGroup::create(createStateSetWithGraphicsPipeline(shaderModeMask, geometrymask, maxNumDescriptors, vertexShaderPath, fragmentShaderPath));
 
         group->addChild(graphicsPipelineGroup);
 


### PR DESCRIPTION
Also support #pragma import_defines, so now we use the shader mode mask to generate a list of defines then compare them to the import defines, then only add the defines that are requested and in the import defines list.

Added text versions of the fbxshader to data/shaders folder. If ypu pass a cutom shader with the args --vert, --frag you need to pass the full path, it's not using findFile or anything like that.

