### PR TITLE
Added support for Material uniform mimicing osg::Material values

### DIFF
--- a/data/shaders/fbxshader.frag
+++ b/data/shaders/fbxshader.frag
@@ -1,32 +1,41 @@
 #version 450
-#pragma import_defines ( VSG_NORMAL, VSG_COLOR, VSG_TEXCOORD0, VSG_LIGHTING, VSG_DIFFUSE_MAP, VSG_OPACITY_MAP, VSG_AMBIENT_MAP, VSG_NORMAL_MAP, VSG_SPECULAR_MAP )
+#pragma import_defines ( VSG_NORMAL, VSG_COLOR, VSG_TEXCOORD0, VSG_LIGHTING, VSG_MATERIAL, VSG_DIFFUSE_MAP, VSG_OPACITY_MAP, VSG_AMBIENT_MAP, VSG_NORMAL_MAP, VSG_SPECULAR_MAP )
 #extension GL_ARB_separate_shader_objects : enable
 #ifdef VSG_DIFFUSE_MAP
-layout(binding = 0) uniform sampler2D diffuseMap;
+layout(binding = 0) uniform sampler2D diffuseMap; 
 #endif
 #ifdef VSG_OPACITY_MAP
 layout(binding = 1) uniform sampler2D opacityMap;
 #endif
 #ifdef VSG_AMBIENT_MAP
-layout(binding = 4) uniform sampler2D ambientMap;
+layout(binding = 4) uniform sampler2D ambientMap; 
 #endif
 #ifdef VSG_NORMAL_MAP
 layout(binding = 5) uniform sampler2D normalMap;
 #endif
 #ifdef VSG_SPECULAR_MAP
-layout(binding = 6) uniform sampler2D specularMap;
+layout(binding = 6) uniform sampler2D specularMap; 
+#endif
+#ifdef VSG_MATERIAL
+layout(binding = 10) uniform MaterialData
+{
+    vec4 ambientColor;
+    vec4 diffuseColor; 
+    vec4 specularColor;
+    float shine; 
+} material;
 #endif
 #ifdef VSG_NORMAL
-layout(location = 1) in vec3 normalDir;
+layout(location = 1) in vec3 normalDir; 
 #endif
 #ifdef VSG_COLOR
-layout(location = 3) in vec4 vertColor;
+layout(location = 3) in vec4 vertColor; 
 #endif
 #ifdef VSG_TEXCOORD0
 layout(location = 4) in vec2 texCoord0;
 #endif
 #ifdef VSG_LIGHTING
-layout(location = 5) in vec3 viewDir;
+layout(location = 5) in vec3 viewDir; 
 layout(location = 6) in vec3 lightDir;
 #endif
 layout(location = 0) out vec4 outColor;
@@ -41,15 +50,22 @@ void main()
 #ifdef VSG_COLOR
     base = base * vertColor;
 #endif
-#ifdef VSG_AMBIENT_MAP
-    float ambientOcclusion = texture(ambientMap, texCoord0.st).r;
+#ifdef VSG_MATERIAL
+    vec3 ambientColor = material.ambientColor.rgb;
+    vec3 diffuseColor = material.diffuseColor.rgb;
+    vec3 specularColor = material.specularColor.rgb;
+    float shine = material.shine;
 #else
-    float ambientOcclusion = 1.0;
+    vec3 ambientColor = vec3(0.1,0.1,0.1);
+    vec3 diffuseColor = vec3(1.0,1.0,1.0);
+    vec3 specularColor = vec3(0.3,0.3,0.3);
+    float shine = material.shine;
+#endif
+#ifdef VSG_AMBIENT_MAP
+    ambientColor *= texture(ambientMap, texCoord0.st).r;
 #endif
 #ifdef VSG_SPECULAR_MAP
-    vec3 specularColor = texture(specularMap, texCoord0.st).rgb;
-#else
-    vec3 specularColor = vec3(0.2,0.2,0.2);
+    specularColor = texture(specularMap, texCoord0.st).rrr;
 #endif
 #ifdef VSG_LIGHTING
 #ifdef VSG_NORMAL_MAP
@@ -62,22 +78,23 @@ void main()
     vec3 ld = normalize(lightDir);
     vec3 vd = normalize(viewDir);
     vec4 color = vec4(0.01, 0.01, 0.01, 1.0);
-    color += /*osg_Material.ambient*/ vec4(0.1, 0.1, 0.1, 0.0);
+    color.rgb += ambientColor;
     float diff = max(dot(ld, nd), 0.0);
-    color += /*osg_Material.diffuse*/ vec4(0.8, 0.8, 0.8, 0.0) * diff;
-    color *= ambientOcclusion;
+    color.rgb += diffuseColor * diff;
     color *= base;
     if (diff > 0.0)
     {
         vec3 halfDir = normalize(ld + vd);
         color.rgb += base.a * specularColor *
-            pow(max(dot(halfDir, nd), 0.0), 16.0/*osg_Material.shine*/);
+            pow(max(dot(halfDir, nd), 0.0), shine);
     }
 #else
     vec4 color = base;
+	color.rgb *= diffuseColor;
 #endif
     outColor = color;
 #ifdef VSG_OPACITY_MAP
     outColor.a *= texture(opacityMap, texCoord0.st).r;
 #endif
 }
+

--- a/include/osg2vsg/GeometryUtils.h
+++ b/include/osg2vsg/GeometryUtils.h
@@ -5,6 +5,7 @@
 
 #include <osg/Array>
 #include <osg/Geometry>
+#include <osg/Material>
 
 namespace osg2vsg
 {
@@ -32,6 +33,16 @@ namespace osg2vsg
         TEXCOORD2_CHANNEL = TEXCOORD0_CHANNEL + 2,
     };
 
+    struct MaterialData
+    {
+        vsg::vec4 ambientColor;
+        vsg::vec4 diffuseColor;
+        vsg::vec4 specularColor;
+        float shine;
+    };
+    
+    using MaterialValue = vsg::UniformValue<MaterialData>;
+
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::vec2Array> convertToVsg(const osg::Vec2Array* inarray, bool duplicate = false, uint32_t dupcount = 0);
 
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::vec3Array> convertToVsg(const osg::Vec3Array* inarray, bool duplicate = false, uint32_t dupcount = 0);
@@ -49,6 +60,8 @@ namespace osg2vsg
     extern OSG2VSG_DECLSPEC std::pair<VkFilter, VkSamplerMipmapMode> convertToFilterAndMipmapMode(osg::Texture::FilterMode filtermode);
 
     extern OSG2VSG_DECLSPEC VkSamplerCreateInfo convertToSamplerCreateInfo(const osg::Texture* texture);
+
+    extern OSG2VSG_DECLSPEC vsg::ref_ptr<MaterialValue> convertToMaterialValue(const osg::Material* material);
 
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::Geometry> convertToVsg(osg::Geometry* geometry, uint32_t requiredAttributesMask = 0);
 

--- a/include/osg2vsg/ShaderUtils.h
+++ b/include/osg2vsg/ShaderUtils.h
@@ -13,12 +13,15 @@ namespace osg2vsg
     {
         NONE = 0,
         LIGHTING = 1,
-        DIFFUSE_MAP = 2,
-        OPACITY_MAP = 4,
-        AMBIENT_MAP = 8,
-        NORMAL_MAP = 16,
-        SPECULAR_MAP = 32,
-        ALL_SHADER_MODE_MASK = LIGHTING | DIFFUSE_MAP | OPACITY_MAP | AMBIENT_MAP | NORMAL_MAP | SPECULAR_MAP
+        MATERIAL = 2,
+        BLEND = 4,
+        BILLBOARD = 8,
+        DIFFUSE_MAP = 16,
+        OPACITY_MAP = 32,
+        AMBIENT_MAP = 64,
+        NORMAL_MAP = 128,
+        SPECULAR_MAP = 256,
+        ALL_SHADER_MODE_MASK = LIGHTING | MATERIAL | BLEND | BILLBOARD | DIFFUSE_MAP | OPACITY_MAP | AMBIENT_MAP | NORMAL_MAP | SPECULAR_MAP
     };
 
     // taken from osg fbx plugin
@@ -34,7 +37,7 @@ namespace osg2vsg
         SHININESS_TEXTURE_UNIT
     };
 
-    extern OSG2VSG_DECLSPEC uint32_t calculateShaderModeMask(osg::StateSet* stateSet);
+    extern OSG2VSG_DECLSPEC uint32_t calculateShaderModeMask(const osg::StateSet* stateSet);
 
     // read a glsl file and inject defines based on shadermodemask and geometryatts
     extern OSG2VSG_DECLSPEC std::string readGLSLShader(const std::string& filename, const uint32_t& shaderModeMask, const uint32_t& geometryAttrbutes);

--- a/src/osg2vsg/GeometryUtils.cpp
+++ b/src/osg2vsg/GeometryUtils.cpp
@@ -171,6 +171,7 @@ namespace osg2vsg
         matvalue->value().ambientColor = vsg::vec4(ambient.x(), ambient.y(), ambient.z(), ambient.w());
 
         osg::Vec4 diffuse = material->getDiffuse(osg::Material::Face::FRONT);
+        if(diffuse.x() == 0.0f && diffuse.y() == 0.0f && diffuse.z() == 0.0f) diffuse.set(1.0f,1.0f,1.0f,1.0f);
         matvalue->value().diffuseColor = vsg::vec4(diffuse.x(), diffuse.y(), diffuse.z(), diffuse.w());
 
         osg::Vec4 specular = material->getSpecular(osg::Material::Face::FRONT);

--- a/src/osg2vsg/ShaderUtils.cpp
+++ b/src/osg2vsg/ShaderUtils.cpp
@@ -18,23 +18,25 @@ using namespace osg2vsg;
 #define DEBUG_OUTPUT if (false) std::cout
 #endif
 
-uint32_t osg2vsg::calculateShaderModeMask(osg::StateSet* stateSet)
+uint32_t osg2vsg::calculateShaderModeMask(const osg::StateSet* stateSet)
 {
     uint32_t stateMask = 0;
     if (stateSet)
     {
-        //if (stateSet->getMode(GL_BLEND) & osg::StateAttribute::ON)
-        //    stateMask |= ShaderGen::BLEND;
+        if (stateSet->getMode(GL_BLEND) & osg::StateAttribute::ON) stateMask |= BLEND;
         if (stateSet->getMode(GL_LIGHTING) & osg::StateAttribute::ON)  stateMask |= LIGHTING;
 
-        auto hasTextureWithImageInChannel = [](osg::StateSet* stateSet, unsigned int channel)
+        auto asMaterial = dynamic_cast<const osg::Material*>(stateSet->getAttribute(osg::StateAttribute::Type::MATERIAL));
+        if (asMaterial) stateMask |= MATERIAL;
+
+        auto hasTextureWithImageInChannel = [](const osg::StateSet* stateSet, unsigned int channel)
         {
-            auto asTex = dynamic_cast<osg::Texture*>(stateSet->getTextureAttribute(channel, osg::StateAttribute::TEXTURE));
+            auto asTex = dynamic_cast<const osg::Texture*>(stateSet->getTextureAttribute(channel, osg::StateAttribute::TEXTURE));
             if (asTex && asTex->getImage(0)) return true;
             return false;
         };
 
-        if (hasTextureWithImageInChannel(stateSet, 0)) stateMask |= DIFFUSE_MAP;
+        if (hasTextureWithImageInChannel(stateSet, DIFFUSE_TEXTURE_UNIT)) stateMask |= DIFFUSE_MAP;
         if (hasTextureWithImageInChannel(stateSet, OPACITY_TEXTURE_UNIT)) stateMask |= OPACITY_MAP;
         if (hasTextureWithImageInChannel(stateSet, AMBIENT_TEXTURE_UNIT)) stateMask |= AMBIENT_MAP;
         if (hasTextureWithImageInChannel(stateSet, NORMAL_TEXTURE_UNIT)) stateMask |= NORMAL_MAP;
@@ -62,6 +64,9 @@ std::vector<std::string> createPSCDefineStrings(const uint32_t& shaderModeMask, 
 
     // shading modes/maps
     if (hasnormal && (shaderModeMask & LIGHTING)) defines.push_back("VSG_LIGHTING");
+    
+    if(shaderModeMask & MATERIAL) defines.push_back("VSG_MATERIAL");
+
     if (hastex0 && (shaderModeMask & DIFFUSE_MAP)) defines.push_back("VSG_DIFFUSE_MAP");
     if (hastex0 && (shaderModeMask & OPACITY_MAP)) defines.push_back("VSG_OPACITY_MAP");
     if (hastex0 && (shaderModeMask & AMBIENT_MAP)) defines.push_back("VSG_AMBIENT_MAP");
@@ -299,7 +304,7 @@ std::string osg2vsg::createFragmentSource(const uint32_t& shaderModeMask, const 
 {
     std::string source =
         "#version 450\n" \
-        "#pragma import_defines ( VSG_NORMAL, VSG_COLOR, VSG_TEXCOORD0, VSG_LIGHTING, VSG_DIFFUSE_MAP, VSG_OPACITY_MAP, VSG_AMBIENT_MAP, VSG_NORMAL_MAP, VSG_SPECULAR_MAP )\n" \
+        "#pragma import_defines ( VSG_NORMAL, VSG_COLOR, VSG_TEXCOORD0, VSG_LIGHTING, VSG_MATERIAL, VSG_DIFFUSE_MAP, VSG_OPACITY_MAP, VSG_AMBIENT_MAP, VSG_NORMAL_MAP, VSG_SPECULAR_MAP )\n" \
         "#extension GL_ARB_separate_shader_objects : enable\n" \
         "#ifdef VSG_DIFFUSE_MAP\n" \
         "layout(binding = 0) uniform sampler2D diffuseMap; \n" \
@@ -315,6 +320,16 @@ std::string osg2vsg::createFragmentSource(const uint32_t& shaderModeMask, const 
         "#endif\n" \
         "#ifdef VSG_SPECULAR_MAP\n" \
         "layout(binding = 6) uniform sampler2D specularMap; \n" \
+        "#endif\n" \
+
+        "#ifdef VSG_MATERIAL\n" \
+        "layout(binding = 10) uniform MaterialData\n" \
+        "{\n" \
+        "    vec4 ambientColor;\n" \
+        "    vec4 diffuseColor; \n" \
+        "    vec4 specularColor;\n" \
+        "    float shine; \n" \
+        "} material;\n" \
         "#endif\n" \
 
         "#ifdef VSG_NORMAL\n" \
@@ -342,15 +357,22 @@ std::string osg2vsg::createFragmentSource(const uint32_t& shaderModeMask, const 
         "#ifdef VSG_COLOR\n" \
         "    base = base * vertColor;\n" \
         "#endif\n" \
-        "#ifdef VSG_AMBIENT_MAP\n" \
-        "    float ambientOcclusion = texture(ambientMap, texCoord0.st).r;\n" \
+        "#ifdef VSG_MATERIAL\n" \
+        "    vec3 ambientColor = material.ambientColor.rgb;\n" \
+        "    vec3 diffuseColor = material.diffuseColor.rgb;\n" \
+        "    vec3 specularColor = material.specularColor.rgb;\n" \
+        "    float shine = material.shine;\n" \
         "#else\n" \
-        "    float ambientOcclusion = 1.0;\n" \
+        "    vec3 ambientColor = vec3(0.1,0.1,0.1);\n" \
+        "    vec3 diffuseColor = vec3(1.0,1.0,1.0);\n" \
+        "    vec3 specularColor = vec3(0.3,0.3,0.3);\n" \
+        "    float shine = material.shine;\n" \
+        "#endif\n" \
+        "#ifdef VSG_AMBIENT_MAP\n" \
+        "    ambientColor *= texture(ambientMap, texCoord0.st).r;\n" \
         "#endif\n" \
         "#ifdef VSG_SPECULAR_MAP\n" \
-        "    vec3 specularColor = texture(specularMap, texCoord0.st).rgb;\n" \
-        "#else\n" \
-        "    vec3 specularColor = vec3(0.2,0.2,0.2);\n" \
+        "    specularColor = texture(specularMap, texCoord0.st).rrr;\n" \
         "#endif\n" \
         "#ifdef VSG_LIGHTING\n" \
         "#ifdef VSG_NORMAL_MAP\n" \
@@ -363,19 +385,19 @@ std::string osg2vsg::createFragmentSource(const uint32_t& shaderModeMask, const 
         "    vec3 ld = normalize(lightDir);\n" \
         "    vec3 vd = normalize(viewDir);\n" \
         "    vec4 color = vec4(0.01, 0.01, 0.01, 1.0);\n" \
-        "    color += /*osg_Material.ambient*/ vec4(0.1, 0.1, 0.1, 0.0);\n" \
+        "    color.rgb += ambientColor;\n" \
         "    float diff = max(dot(ld, nd), 0.0);\n" \
-        "    color += /*osg_Material.diffuse*/ vec4(0.8, 0.8, 0.8, 0.0) * diff;\n" \
-        "    color *= ambientOcclusion;\n" \
+        "    color.rgb += diffuseColor * diff;\n" \
         "    color *= base;\n" \
         "    if (diff > 0.0)\n" \
         "    {\n" \
         "        vec3 halfDir = normalize(ld + vd);\n" \
         "        color.rgb += base.a * specularColor *\n" \
-        "            pow(max(dot(halfDir, nd), 0.0), 16.0/*osg_Material.shine*/);\n" \
+        "            pow(max(dot(halfDir, nd), 0.0), shine);\n" \
         "    }\n" \
         "#else\n" \
         "    vec4 color = base;\n" \
+        "    color.rgb *= diffuseColor;\n" \
         "#endif\n" \
         "    outColor = color;\n" \
         "#ifdef VSG_OPACITY_MAP\n" \


### PR DESCRIPTION
Here's changes to add support for osg Material. I've added new ShaderModeMask values. If an osg Material is present the Material mask is added. We use that to indicate we should create a vsg Uniform and add the appropriate descriptorlayout. 