### PR TITLE
Geometry target

### DIFF
--- a/applications/osg2vsg/osg2vsg.cpp
+++ b/applications/osg2vsg/osg2vsg.cpp
@@ -217,6 +217,9 @@ int main(int argc, char** argv)
     if (arguments.read("--cull-nodes")) sceneBuilder.insertCullNodes = true;
     if (arguments.read("--no-cull-nodes")) sceneBuilder.insertCullNodes = false;
     if (arguments.read("--no-culling")) { sceneBuilder.insertCullGroups = false; sceneBuilder.insertCullNodes = false; }
+    if (arguments.read("--Geometry")) { sceneBuilder.geometryTarget = osg2vsg::VSG_GEOMETRY; }
+    if (arguments.read("--VertexIndexDraw")) { sceneBuilder.geometryTarget = osg2vsg::VSG_VERTEXINDEXDRAW; }
+    if (arguments.read("--Commands")) { sceneBuilder.geometryTarget = osg2vsg::VSG_COMMANDS; }
     if (arguments.read({"--bind-single-ds", "--bsds"})) sceneBuilder.useBindDescriptorSet = true;
     auto numFrames = arguments.value(-1, "-f");
     auto writeToFileProgramAndDataSetSets = arguments.read({"--write-stateset", "--ws"});

--- a/applications/osg2vsg/osg2vsg.cpp
+++ b/applications/osg2vsg/osg2vsg.cpp
@@ -175,6 +175,22 @@ namespace osg2vsg
             }
         }
 
+        void apply(vsg::BindVertexBuffers& bvb) override
+        {
+            for(auto& data : bvb.getArrays())
+            {
+                objects->addChild(data);
+            }
+        }
+
+        void apply(vsg::BindIndexBuffer& bib) override
+        {
+            if (bib.getIndices())
+            {
+                objects->addChild(vsg::ref_ptr<vsg::Data>(bib.getIndices()));
+            }
+        }
+
         void apply(vsg::StateGroup& stategroup) override
         {
             for(auto& command : stategroup.getStateCommands())

--- a/include/osg2vsg/GeometryUtils.h
+++ b/include/osg2vsg/GeometryUtils.h
@@ -36,6 +36,12 @@ namespace osg2vsg
         TEXCOORD2_CHANNEL = TEXCOORD0_CHANNEL + 2,
     };
 
+    enum GeometryTarget : uint32_t
+    {
+        VSG_GEOMETRY,
+        VSG_VERTEXINDEXDRAW,
+        VSG_COMMANDS
+    };
 
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::vec2Array> convertToVsg(const osg::Vec2Array* inarray);
 
@@ -57,6 +63,6 @@ namespace osg2vsg
 
     extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::MaterialValue> convertToMaterialValue(const osg::Material* material);
 
-    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::Command> convertToVsg(osg::Geometry* geometry, uint32_t requiredAttributesMask, bool useVsgGeometryOnly);
+    extern OSG2VSG_DECLSPEC vsg::ref_ptr<vsg::Command> convertToVsg(osg::Geometry* geometry, uint32_t requiredAttributesMask, GeometryTarget geometryTarget);
 
 }

--- a/include/osg2vsg/SceneBuilder.h
+++ b/include/osg2vsg/SceneBuilder.h
@@ -72,7 +72,9 @@ namespace osg2vsg
         bool insertCullGroups = true;
         bool insertCullNodes = true;
         bool useBindDescriptorSet = true;
-        bool useVsgGeometryOnly = false;
+
+        GeometryTarget geometryTarget = VSG_VERTEXINDEXDRAW;
+
         uint32_t supportedGeometryAttributes = GeometryAttributes::ALL_ATTS;
         uint32_t supportedShaderModeMask = ShaderModeMask::ALL_SHADER_MODE_MASK;
         uint32_t overrideGeomAttributes = 0;

--- a/src/osg2vsg/SceneBuilder.cpp
+++ b/src/osg2vsg/SceneBuilder.cpp
@@ -487,7 +487,7 @@ vsg::ref_ptr<vsg::Node> SceneBuilder::createTransformGeometryGraphVSG(TransformG
             }
             else
             {
-                leaf = convertToVsg(geometry, requiredGeomAttributesMask, useVsgGeometryOnly);
+                leaf = convertToVsg(geometry, requiredGeomAttributesMask, geometryTarget);
                 if (leaf)
                 {
                     geometriesMap[geometry] = leaf;


### PR DESCRIPTION
Added ability to select what type of geometry to create when converting OSG to VSG scene graphs.

   --Geometry  selects vsg::Geometry
   --Commands selects vsg::Commands containing BindVertexBuffers and BindIndexBuffers and Draw*
   --VertexIndexDraw selects vsg::VertexIndexDraw