### PR TITLE
Simplified glinterop example

### DIFF
--- a/applications/vsgglinterop/vsgglinterop.cpp
+++ b/applications/vsgglinterop/vsgglinterop.cpp
@@ -538,8 +538,8 @@ int main(int argc, char** argv)
     bool rttDemo = arguments.read("--osgrtt");
     if (rttDemo)
     {
-        colorUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-        colorLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        //colorUsageFlags = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT; // these cause validation errors
+        //colorLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     }
     else
     {


### PR DESCRIPTION
By default it loads textures/osglogo.png from the VSG_FILE_PATH. It needs to be a png with transparency. The image will be loaded as an osg image and set as the image on the shareTexture. That texture is shareing memory with the shareColorimage and so it gets displayed in the vsg window using it in a descriptor.

The other mode is activated with option --osgrtt it instead creates and osg scene that renders into an osg texture a postDrawCallback is then used to copy the texture into the sharedTexture which same as above is linked to the vsg image and so displayed in the vsg window