### PR TITLE
Fix not using install related settings from vsg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(OSG2VSG
+project(osg2vsg
     VERSION 0.1.0
     DESCRIPTION "OpenSceneGraph/VulkanSceneGraph integration library"
     LANGUAGES CXX
@@ -88,6 +88,8 @@ endif()
 
 find_package(vsg 1.0.0)
 
+vsg_setup_dir_vars()
+vsg_setup_build_vars()
 
 # only provide custom targets if not building as a submodule/FetchContent
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})

--- a/src/osg2vsg/CMakeLists.txt
+++ b/src/osg2vsg/CMakeLists.txt
@@ -46,12 +46,7 @@ target_link_libraries(osg2vsg
 )
 
 
-install(TARGETS osg2vsg EXPORT osg2vsgTargets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
-)
+install(TARGETS osg2vsg ${INSTALL_TARGETS_DEFAULT_FLAGS})
 
 target_compile_definitions(osg2vsg PRIVATE ${EXTRA_DEFINES})
 

--- a/src/osgPlugins/vsg/CMakeLists.txt
+++ b/src/osgPlugins/vsg/CMakeLists.txt
@@ -22,9 +22,4 @@ target_link_libraries(osgdb_vsg PUBLIC
     ${OPENTHREADS_LIBRARIES} ${OSG_LIBRARIES} ${OSGUTIL_LIBRARIES} ${OSGDB_LIBRARIES}
 )
 
-install(TARGETS osgdb_vsg EXPORT osg2vsgTargets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
-)
+install(TARGETS osgdb_vsg ${INSTALL_TARGETS_DEFAULT_FLAGS})


### PR DESCRIPTION
This fixes a bug that on x86_64 systems shared libraries are not installed in lib64.