### PR TITLE
Fix building with MinGW when vsg::Path uses wchar_t

### DIFF
--- a/src/osg2vsg/OSG.cpp
+++ b/src/osg2vsg/OSG.cpp
@@ -103,7 +103,7 @@ vsg::ref_ptr<vsg::Object> OSG::read(const vsg::Path& filename, vsg::ref_ptr<cons
         auto foundPath = vsg::findFile(filename, options);
         if (foundPath)
         {
-            std::ifstream fin(foundPath);
+            std::ifstream fin(foundPath.c_str());
             if (!fin) return {};
 
             osg::ref_ptr<osg::AnimationPath> osg_animationPath = new osg::AnimationPath;


### PR DESCRIPTION
Fix for vsg-dev/VulkanSceneGraph#649