### PR TITLE
Fix inconsistent forward declaration of PipelineCache

### DIFF
--- a/include/osg2vsg/OSG.h
+++ b/include/osg2vsg/OSG.h
@@ -29,7 +29,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 namespace osg2vsg
 {
     // forward declare
-    class PipelineCache;
+    struct PipelineCache;
 
     /// optional OSG ReaderWriter
     class OSG2VSG_DECLSPEC OSG : public vsg::Inherit<vsg::ReaderWriter, OSG>


### PR DESCRIPTION
`PipelineCache` was defined as a `struct` in 

https://github.com/vsg-dev/osg2vsg/blob/b14dddf1f68fa7e5e89574599108a8c4e2146c7f/src/osg2vsg/BuildOptions.h#L21

but it's forward declared as `class` in

https://github.com/vsg-dev/osg2vsg/blob/b14dddf1f68fa7e5e89574599108a8c4e2146c7f/include/osg2vsg/OSG.h#L32