### PR TITLE
Bug fixes: Default vert shader; CMake with osgText

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(OpenGL REQUIRED)
 
 # Find OpenSceneGraph packages for reference
 # set preference for using modern OpenGL library.
-find_package(OpenSceneGraph REQUIRED COMPONENTS osgDB osgTerrain osgUtil osgGA osgViewer)
+find_package(OpenSceneGraph REQUIRED COMPONENTS osgDB osgTerrain osgUtil osgGA osgViewer osgText)
 
 if (VULKAN_SDK)
     set(ENV{VULKAN_SDK} ${VULKAN_SDK})

--- a/applications/vsgwithosg/CMakeLists.txt
+++ b/applications/vsgwithosg/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(vsgwithosg
     ${OSGUTIL_LIBRARIES}
     ${OSGDB_LIBRARIES}
     ${OSGGA_LIBRARIES}
+    ${OSGTEXT_LIBRARIES}
     ${OSGVIEWER_LIBRARIES}
     ${OPENGL_LIBRARIES}
 )

--- a/data/shaders/fbxshader.vert
+++ b/data/shaders/fbxshader.vert
@@ -77,7 +77,7 @@ void main()
 #endif
 #ifdef VSG_LIGHTING
     vec4 lpos = /*osg_LightSource.position*/ vec4(0.0, 0.25, 1.0, 0.0);
-#ifdef VSG_NORMAL_MAP
+#if defined(VSG_NORMAL_MAP) && defined(VSG_TANGENT)
     vec3 t = (modelView * vec4(osg_Tangent.xyz, 0.0)).xyz;
     vec3 b = cross(n, t);
     vec3 dir = -vec3(modelView * vec4(osg_Vertex, 1.0));

--- a/src/osg2vsg/shaders/fbxshader_vert.cpp
+++ b/src/osg2vsg/shaders/fbxshader_vert.cpp
@@ -89,7 +89,7 @@ void main()
 #endif
 #ifdef VSG_LIGHTING
     vec4 lpos = /*osg_LightSource.position*/ vec4(0.0, 0.25, 1.0, 0.0);
-#ifdef VSG_NORMAL_MAP
+#if defined(VSG_NORMAL_MAP) && defined(VSG_TANGENT)
     vec3 t = (modelView * vec4(osg_Tangent.xyz, 0.0)).xyz;
     vec3 b = cross(n, t);
     vec3 dir = -vec3(modelView * vec4(osg_Vertex, 1.0));


### PR DESCRIPTION
- Bugfix: The default vertex shaders no longer break when there is no tangent information on the imported vertices
- Bugfix: osgText is now an explicit dependency within CMake; osgText was apparently a dependency (likely from another osg library). This was an issue when linking statically with VS. 